### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "middist": "^0.2.5",
     "mosca": "^2.5.2",
     "path-rewriter": "^1.0.1",
-    "path-to-regexp": "^2.0.0",
     "plando": "^0.1.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that one of the runtime dependencies is installed, however, it is not used during the test runtime. We removed this dependency from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?